### PR TITLE
notes on geo dns, performance, and obscuring ip addresses

### DIFF
--- a/draft-pauly-adaptive-dns-privacy.md
+++ b/draft-pauly-adaptive-dns-privacy.md
@@ -465,7 +465,7 @@ keys to define the local DoH server and which domains it claims authority over.
 # Performance Considerations
 
 One of the challenges with cloud-based DNS approaches, such as
-Adaptive DNS, is that the address of the recrusive resolver is
+Adaptive DNS, is that the address of the recursive resolver is
 sometimes used as input into DNS geographic load balancing
 sytems. These systems assume the address of the recursive resolver and
 the terminal client are similar. In other cases, the client's actual


### PR DESCRIPTION
I don't know if this is the right way to tackle the topic - but its going to be a big one and I figured I would at least take a poke at it. wdyt?

It also makes me wonder if connections with a designated doh server should be encouraged (!) to use full /32 or /128 ECS in order to signal to the server that's an accurate thing to use