### PR TITLE
Address David's review

### DIFF
--- a/draft-pauly-dprive-oblivious-doh.md
+++ b/draft-pauly-dprive-oblivious-doh.md
@@ -154,7 +154,13 @@ as an HTTP request using the POST method. Requests to the Proxy indicate
 which DoH server to use as a Target by specifying two variables: "targethost",
 which indicates the host name of the Target server, and "targetpath", which
 indicates the path on which the Target's DoH server is running. See
-{{request-example}} for an example request.
+{{request-example}} for an example request. Clients are configured with a Proxy
+URI Template which contains these two variables. Examples are shown below:
+
+~~~
+https://dnsproxy.example/dns-query{?targethost,targetpath}
+https://dnsproxy.example/{targethost}/{targetpath}
+~~~
 
 Oblivious DoH messages have no cache value since both requests and responses are
 encrypted using ephemeral key material. Clients SHOULD indicate this using
@@ -166,8 +172,7 @@ also SHOULD set this same value for the HTTP Accept header.
 
 A correctly encoded request has the HTTP Content-Type header "application/oblivious-dns-message",
 uses the HTTP POST method, and contains "targethost" and "targetpath" variables.
-The "targethost" and "targetpath" variables are used to construct the request to forward to
-the Target. The Proxy MUST validate these parameters and construct this request as follows:
+The Proxy MUST validate these parameters and construct a URI Template as follows:
 
 1. Let $TARGET be the "targethost" parameter from the Client's request, encoded as the
 concatenation of a "host" value (Section 3.2.2 of {{!RFC3986}}) and, optionally, the
@@ -176,7 +181,9 @@ be encoded as such, the Client's request is incorrectly encoded.
 1. Let $PATH be the "targetpath" parameter from the Client's request, which MUST be a URI
 Template {{!RFC6570}}. If this parameter is not a valid URI Template, the Client's request
 is incorrectly encoded.
-1. The Target request HTTPS URI template is "https://$TARGET$PATH".
+1. The Target request HTTPS URI Template is "https://$TARGET$PATH".
+
+The resulting URI from this Template is used to forward the Client's request to the Target.
 
 Proxies MUST check that Client requests are correctly encoded, and MUST return a
 4xx (Client Error) if the check fails, along with the Proxy-Status response header
@@ -198,7 +205,7 @@ Targets MUST return 4xx (Client Error) if this check fails.
 ## HTTP Request Example {#request-example}
 
 The following example shows how a Client requests that a Proxy, "dnsproxy.example",
-forwards an encrypted message to "dnstarget.example". The URI template for the
+forwards an encrypted message to "dnstarget.example". The URI Template for the
 Proxy is "https://dnsproxy.example/dns-query{?targethost,targetpath}". The URI template for
 the Target is "https://dnstarget.example/dns-query".
 

--- a/draft-pauly-dprive-oblivious-doh.md
+++ b/draft-pauly-dprive-oblivious-doh.md
@@ -52,8 +52,8 @@ author:
 
 --- abstract
 
-This document describes a protocol built on DNS Over HTTPS (DoH) that allows hiding
-client IP addresses via proxying encrypted DNS transactions. This improves privacy of
+This document describes a protocol that allows clients to hide their IP addresses from DNS resolvers
+via proxying encrypted DNS over HTTPS (DoH) messages. This improves privacy of
 DNS operations by not allowing any one server entity to be aware of both the client IP
 address and the content of DNS queries and answers.
 

--- a/draft-pauly-dprive-oblivious-doh.md
+++ b/draft-pauly-dprive-oblivious-doh.md
@@ -177,7 +177,7 @@ also SHOULD set this same value for the HTTP Accept header.
 
 A correctly encoded request has the HTTP Content-Type header "application/oblivious-dns-message",
 uses the HTTP POST method, and contains "targethost" and "targetpath" variables. Let
-$TARGET be the "targethost" variable and $PATH be the "targetpath" variable from this
+$TARGET be the "targethost" variable and $PATH be the "targetpath" variable percent-decoded from this
 request. The Proxy constructs a HTTP request to forward the
 Client request to the Target using the URI Template "https://$TARGET$PATH".
 

--- a/draft-pauly-dprive-oblivious-doh.md
+++ b/draft-pauly-dprive-oblivious-doh.md
@@ -155,7 +155,7 @@ which DoH server to use as a Target by specifying two variables: "targethost",
 which indicates the host name of the Target server, and "targetpath", which
 indicates the path on which the Target's DoH server is running. See
 {{request-example}} for an example request. Clients are configured with a Proxy
-URI Template which contains these two variables. Examples are shown below:
+URI Template {{!RFC6570}} which contains these two variables. Examples are shown below:
 
 ~~~
 https://dnsproxy.example/dns-query{?targethost,targetpath}

--- a/draft-pauly-dprive-oblivious-doh.md
+++ b/draft-pauly-dprive-oblivious-doh.md
@@ -176,11 +176,8 @@ to indicate that this request is an Oblivious DoH query intended for proxying. C
 also SHOULD set this same value for the HTTP Accept header.
 
 A correctly encoded request has the HTTP Content-Type header "application/oblivious-dns-message",
-uses the HTTP POST method, and contains "targethost" and "targetpath" variables. Let
-$TARGET be the "targethost" variable and $PATH be the "targetpath" variable percent-decoded from this
-request. The Proxy constructs a HTTP request to forward the
-Client request to the Target using the URI Template "https://$TARGET$PATH".
-
+uses the HTTP POST method, and contains "targethost" and "targetpath" variables. The Proxy constructs 
+the URI of the Target with the "https" scheme, using the value of "targethost" as the URI host the percent-decoded value of "targetpath" as the URI path.
 Proxies MUST check that Client requests are correctly encoded, and MUST return a
 4xx (Client Error) if the check fails, along with the Proxy-Status response header
 with an "error" parameter of type "http_request_error" {{!I-D.ietf-httpbis-proxy-status}}.

--- a/draft-pauly-dprive-oblivious-doh.md
+++ b/draft-pauly-dprive-oblivious-doh.md
@@ -342,7 +342,7 @@ An `ObliviousDoHConfigContents` contains the information needed to encrypt a mes
 `ObliviousDoHConfigContents.public_key` such that only the owner of the corresponding private
 key can decrypt the message. The values for `ObliviousDoHConfigContents.kem_id`,
 `ObliviousDoHConfigContents.kdf_id`, and `ObliviousDoHConfigContents.aead_id`
-are described in Section 7 or {{!HPKE=I-D.irtf-cfrg-hpke}}. The fields in this structure
+are described in Section 7 of {{!HPKE=I-D.irtf-cfrg-hpke}}. The fields in this structure
 are as follows:
 
 kem_id

--- a/draft-pauly-dprive-oblivious-doh.md
+++ b/draft-pauly-dprive-oblivious-doh.md
@@ -149,18 +149,23 @@ Unlike direct resolution, oblivious hostname resolution over DoH involves three 
 
 ## HTTP Request {#oblivious-request}
 
-Oblivious DoH queries are created by the Client, and sent to the Proxy
-as an HTTP request using the POST method. Requests to the Proxy indicate
-which DoH server to use as a Target by specifying two variables: "targethost",
-which indicates the host name of the Target server, and "targetpath", which
-indicates the path on which the Target's DoH server is running. See
-{{request-example}} for an example request. Clients are configured with a Proxy
-URI Template {{!RFC6570}} which contains these two variables. Examples are shown below:
+Oblivious DoH queries are created by the Client, and sent to the Proxy as an HTTP
+request using the POST method. Clients are configured with a Proxy URI Template
+{{!RFC6570}} which contains two variables: "targethost", which indicates the host
+name of the Target server, and "targetpath", which indicates the path on which the
+Target's DoH server is running. Examples of URI templates are shown below:
 
 ~~~
 https://dnsproxy.example/dns-query{?targethost,targetpath}
 https://dnsproxy.example/{targethost}/{targetpath}
 ~~~
+
+The URI template MUST contain both the "targethost" and "targetpath" variables exactly
+once, and MUST NOT contain any other variables. The variables MUST be within the path
+component of the URI. The "targethost" parameter MUST be encoded as the concatenation
+of a "host" value (Section 3.2.2 of {{!RFC3986}}) and, optionally, the ":" character
+followed by a "port" value (Section 3.2.3 of {{!RFC3986}}). The "targetpath" parameter
+MUST be a percent-encoded URI path. See {{request-example}} for an example request.
 
 Oblivious DoH messages have no cache value since both requests and responses are
 encrypted using ephemeral key material. Clients SHOULD indicate this using
@@ -171,19 +176,10 @@ to indicate that this request is an Oblivious DoH query intended for proxying. C
 also SHOULD set this same value for the HTTP Accept header.
 
 A correctly encoded request has the HTTP Content-Type header "application/oblivious-dns-message",
-uses the HTTP POST method, and contains "targethost" and "targetpath" variables.
-The Proxy MUST validate these parameters and construct a URI Template as follows:
-
-1. Let $TARGET be the "targethost" parameter from the Client's request, encoded as the
-concatenation of a "host" value (Section 3.2.2 of {{!RFC3986}}) and, optionally, the
-":" character followed by port (Section 3.2.3 of {{!RFC3986}}). If this parameter cannot
-be encoded as such, the Client's request is incorrectly encoded.
-1. Let $PATH be the "targetpath" parameter from the Client's request, which MUST be a URI
-Template {{!RFC6570}}. If this parameter is not a valid URI Template, the Client's request
-is incorrectly encoded.
-1. The Target request HTTPS URI Template is "https://$TARGET$PATH".
-
-The resulting URI from this Template is used to forward the Client's request to the Target.
+uses the HTTP POST method, and contains "targethost" and "targetpath" variables. Let
+$TARGET be the "targethost" variable and $PATH be the "targetpath" variable from this
+request, encoded as described above. The Proxy constructs a HTTP request to forward the
+Client request to the Target using the URI Template "https://$TARGET$PATH".
 
 Proxies MUST check that Client requests are correctly encoded, and MUST return a
 4xx (Client Error) if the check fails, along with the Proxy-Status response header

--- a/draft-pauly-dprive-oblivious-doh.md
+++ b/draft-pauly-dprive-oblivious-doh.md
@@ -155,7 +155,7 @@ requests using the POST method. Clients are configured with a Proxy URI Template
 the Target URI MUST be "https". The Proxy URI Template contains two variables: 
 "targethost", which indicates the host name of the Target server, and "targetpath",
 which indicates the path on which the Target's DoH server is running. Examples of
-URI templates are shown below:
+Proxy URI Templates are shown below:
 
 ~~~
 https://dnsproxy.example/dns-query{?targethost,targetpath}

--- a/draft-pauly-dprive-oblivious-doh.md
+++ b/draft-pauly-dprive-oblivious-doh.md
@@ -178,7 +178,7 @@ also SHOULD set this same value for the HTTP Accept header.
 A correctly encoded request has the HTTP Content-Type header "application/oblivious-dns-message",
 uses the HTTP POST method, and contains "targethost" and "targetpath" variables. Let
 $TARGET be the "targethost" variable and $PATH be the "targetpath" variable from this
-request, encoded as described above. The Proxy constructs a HTTP request to forward the
+request. The Proxy constructs a HTTP request to forward the
 Client request to the Target using the URI Template "https://$TARGET$PATH".
 
 Proxies MUST check that Client requests are correctly encoded, and MUST return a

--- a/draft-pauly-dprive-oblivious-doh.md
+++ b/draft-pauly-dprive-oblivious-doh.md
@@ -149,8 +149,8 @@ Unlike direct resolution, oblivious hostname resolution over DoH involves three 
 
 ## HTTP Request {#oblivious-request}
 
-Oblivious DoH queries are created by the Client, and sent to the Proxy as an HTTP
-request using the POST method. Clients are configured with a Proxy URI Template
+Oblivious DoH queries are created by the Client, and sent to the Proxy as HTTP
+requests using the POST method. Clients are configured with a Proxy URI Template
 {{!RFC6570}} which contains two variables: "targethost", which indicates the host
 name of the Target server, and "targetpath", which indicates the path on which the
 Target's DoH server is running. Examples of URI templates are shown below:


### PR DESCRIPTION
Closes #206. This specifies the URI Template for the proxy (and how parameters are encoded), as well as the URI Template for forwarded requests. I _think_ it captures things correctly based on my reading of RFC6570.

cc @DavidSchinazi